### PR TITLE
Drupal has two elasticsearch modules

### DIFF
--- a/index.php
+++ b/index.php
@@ -47,7 +47,7 @@ include_once("inc/header.php");
     <tr>
       <td>3rd-party product integration (open-source)<a href="#" title="3rd-party open-source products which use Solr to provide search functionality." class="tt"><img src="img/help.png"></a></td>
       <td>Drupal, Magento, Django, ColdFusion, Wordpress, OpenCMS, Plone, Typo3, ez Publish, Symfony2, Riak (via Yokozuna)</td>
-      <td>Django, Symfony2</td>
+      <td>Drupal, Django, Symfony2</td>
     </tr>
     <tr>
       <td>3rd-party product integration (commercial)<a href="#" title="3rd-party commercial products which use Solr to provide search functionality." class="tt"><img src="img/help.png"></a></td>


### PR DESCRIPTION
Drupal has two elasticsearch modules:
- https://drupal.org/project/elasticsearch
- https://drupal.org/project/search_api_elasticsearch
