### PR TITLE
update es support with tempest

### DIFF
--- a/index.php
+++ b/index.php
@@ -501,7 +501,7 @@ include_once("inc/header.php");
     <tr>
       <td>Pluggable shard/replica assignment </td>
       <td><img src="img/tick.png"> <a href="https://cwiki.apache.org/confluence/display/solr/Rule-based+Replica+Placement">Rule-based replica assignment</a></td>
-      <td><img src="img/cross.png"> Partially-supported with <a href="https://github.com/datarank/tempest">Tempest plugin</a></td>
+      <td><img src="img/tick.png"> Probabilistic shard balancing with <a href="https://github.com/datarank/tempest">Tempest plugin</a></td>
     </tr> 
     <tr>
       <td>Consistency</td>


### PR DESCRIPTION
@superkelvint We have updated Tempest to be compatible with ES 2.2.3, 1.7.5, 1.5.2, 1.4.3. Previously it only had support for 1.4.3. This is a full rewrite and major release. https://github.com/datarank/tempest

Thanks for finding Tempest and adding it in the first place! :)

